### PR TITLE
Add AceTeam-specific gateway startup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,8 @@ COPY --from=runtime-assets --chown=node:node /app/${OPENCLAW_BUNDLED_PLUGIN_DIR}
 COPY --from=runtime-assets --chown=node:node /app/skills ./skills
 COPY --from=runtime-assets --chown=node:node /app/docs ./docs
 COPY --from=runtime-assets --chown=node:node /app/qa ./qa
+# AceTeam Railway: keep this COPY after upstream assets; startCommand passes base64 JSON as argv (see aceteam repo).
+COPY --chmod=755 --chown=node:node docker/aceteam-hosted-entrypoint.sh /app/aceteam-hosted-entrypoint.sh
 
 # Keep pnpm available in the runtime image for container-local workflows.
 # Use a shared Corepack home so the non-root `node` user does not need a

--- a/docker/aceteam-hosted-entrypoint.sh
+++ b/docker/aceteam-hosted-entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# AceTeam-hosted SafeClaw: writes ~/.openclaw/openclaw.json from the first
+# argument (base64-encoded JSON from Railway startCommand), then execs the gateway.
+
+set -eu
+
+CONFIG_PATH="/home/node/.openclaw/openclaw.json"
+log() {
+  printf '%s\n' "$*" >&2
+}
+
+log "[aceteam-hosted-entrypoint] writing config to ${CONFIG_PATH}"
+mkdir -p /home/node/.openclaw
+
+b64="${1-}"
+if [ -z "$b64" ]; then
+  log "[aceteam-hosted-entrypoint] error: missing base64 JSON argument"
+  exit 1
+fi
+
+printf '%s' "$b64" | base64 -d >"$CONFIG_PATH"
+
+if [ ! -s "$CONFIG_PATH" ]; then
+  log "[aceteam-hosted-entrypoint] error: decoded config is empty"
+  exit 1
+fi
+
+log "[aceteam-hosted-entrypoint] exec openclaw gateway"
+exec node /app/openclaw.mjs gateway


### PR DESCRIPTION
This script should help us debug entrypoint exits more easily.

Usage:

```
exec /app/aceteam-hosted-entrypoint.sh '${configB64}'
```