### PR TITLE
feat: verify container daemon and add workshop outro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 # SafeClaw — Run OpenClaw Safely
 
+SafeClaw puts OpenClaw in a container where it can't touch your local files, email, or credentials — and blocks dangerous actions before they execute.
+
+## Installation
+
+### One-Line Installer (Recommended)
+
+#### Linux / macOS
+
+```bash
+curl -fsSL https://safeclaw.sh/install.sh | bash
+```
+
+#### Windows (PowerShell)
+
+```powershell
+iwr -useb https://safeclaw.sh/install.ps1 | iex
+```
+
+### Manual Installation (Container)
+
+If you prefer to run the containers manually:
+
 ```bash
 # Pull the latest SafeClaw Agent image
 docker pull ghcr.io/aceteam-ai/safeclaw:9ca8671
@@ -8,7 +30,34 @@ docker pull ghcr.io/aceteam-ai/safeclaw:9ca8671
 docker pull ghcr.io/aceteam-ai/aep-proxy:latest
 ```
 
-> **OpenClaw is powerful. It has access to your email, your files, your credentials. SafeClaw puts it in a container where it can't touch any of that — and blocks dangerous actions before they execute.**
+## Quick Start (Complete Safe Stack)
+
+The easiest way to run the full SafeClaw agent with automatic safety enforcement is using Docker Compose:
+
+```bash
+# Docker 
+docker compose -f docker-compose.yml -f docker-compose.safe.yml up
+
+# Podman
+podman-compose -f docker-compose.yml -f docker-compose.safe.yml up
+```
+
+## Running the Safety Proxy Alone
+
+If you already have an agent (OpenClaw, NemoClaw, etc.) and just want to add the safety layer:
+
+```bash
+# Docker
+docker run -p 8899:8899 ghcr.io/aceteam-ai/aep-proxy:latest
+
+# Podman
+podman run -p 8899:8899 ghcr.io/aceteam-ai/aep-proxy:latest
+```
+
+Dashboard: **http://localhost:8899/aep/**
+API Keys: Configure in **Dashboard > Settings**
+
+---
 
 ## The Problem
 
@@ -102,7 +151,6 @@ aceteam-aep keygen
 
 # Run with signed verdicts
 docker run -p 8899:8899 \
-  -e OPENAI_API_KEY=$OPENAI_API_KEY \
   -v ./aep.key:/app/aep.key:ro \
   ghcr.io/aceteam-ai/aep-proxy:latest \
   proxy --port 8899 --host 0.0.0.0 --sign-key /app/aep.key
@@ -159,10 +207,10 @@ Open **http://localhost:8899/aep/** while your agent runs:
 
 ```bash
 # Docker
-docker run -p 8899:8899 -e OPENAI_API_KEY=$OPENAI_API_KEY ghcr.io/aceteam-ai/aep-proxy:latest
+docker run -p 8899:8899 ghcr.io/aceteam-ai/aep-proxy:latest
 
 # Podman
-podman run -p 8899:8899 -e OPENAI_API_KEY=$OPENAI_API_KEY ghcr.io/aceteam-ai/aep-proxy:latest
+podman run -p 8899:8899 ghcr.io/aceteam-ai/aep-proxy:latest
 ```
 
 **pip (developer mode — runs on host):**

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # SafeClaw — Run OpenClaw Safely
 
+```bash
+# Pull the latest SafeClaw Agent image
+docker pull ghcr.io/aceteam-ai/safeclaw:9ca8671
+
+# Pull the AEP Safety Proxy image
+docker pull ghcr.io/aceteam-ai/aep-proxy:latest
+```
+
 > **OpenClaw is powerful. It has access to your email, your files, your credentials. SafeClaw puts it in a container where it can't touch any of that — and blocks dangerous actions before they execute.**
 
 ## The Problem
@@ -30,11 +38,28 @@ Your laptop (safe)          Docker container (sandboxed)
 
 The agent runs inside a Docker container. It **cannot** access your files, email, browser cookies, or credentials. The only thing exposed is port 8899 — the safety dashboard.
 
-## Quick Start
+## Quick Start (Complete Safe Stack)
+
+The easiest way to run the full SafeClaw agent with automatic safety enforcement is using Docker Compose:
 
 ```bash
-# One command. No Node. No Python. Just Docker.
-docker run -p 8899:8899 -e OPENAI_API_KEY=$OPENAI_API_KEY ghcr.io/aceteam-ai/aep-proxy
+# Docker 
+docker compose -f docker-compose.yml -f docker-compose.safe.yml up
+
+# Podman
+podman-compose -f docker-compose.yml -f docker-compose.safe.yml up
+```
+
+## Running the Safety Proxy Alone
+
+If you already have an agent (OpenClaw, NemoClaw, etc.) and just want to add the safety layer:
+
+```bash
+# Docker
+docker run -p 8899:8899 -e OPENAI_API_KEY=$OPENAI_API_KEY ghcr.io/aceteam-ai/aep-proxy:latest
+
+# Podman
+podman run -p 8899:8899 -e OPENAI_API_KEY=$OPENAI_API_KEY ghcr.io/aceteam-ai/aep-proxy:latest
 ```
 
 Dashboard: **http://localhost:8899/aep/**
@@ -79,7 +104,7 @@ aceteam-aep keygen
 docker run -p 8899:8899 \
   -e OPENAI_API_KEY=$OPENAI_API_KEY \
   -v ./aep.key:/app/aep.key:ro \
-  ghcr.io/aceteam-ai/aep-proxy \
+  ghcr.io/aceteam-ai/aep-proxy:latest \
   proxy --port 8899 --host 0.0.0.0 --sign-key /app/aep.key
 ```
 
@@ -130,10 +155,14 @@ Open **http://localhost:8899/aep/** while your agent runs:
 
 ## Install Options
 
-**Docker (recommended — sandboxed, no file access):**
+**Docker / Podman (recommended — sandboxed, no file access):**
 
 ```bash
-docker run -p 8899:8899 -e OPENAI_API_KEY=$OPENAI_API_KEY ghcr.io/aceteam-ai/aep-proxy
+# Docker
+docker run -p 8899:8899 -e OPENAI_API_KEY=$OPENAI_API_KEY ghcr.io/aceteam-ai/aep-proxy:latest
+
+# Podman
+podman run -p 8899:8899 -e OPENAI_API_KEY=$OPENAI_API_KEY ghcr.io/aceteam-ai/aep-proxy:latest
 ```
 
 **pip (developer mode — runs on host):**

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 #
 # Usage: curl -fsSL https://safeclaw.sh/install.sh | sh
 #
-# Checks Docker or Python, installs AEP safety proxy.
+# Checks Podman/Docker or Python, installs AEP safety proxy.
 
 set -euo pipefail
 
@@ -20,12 +20,28 @@ echo -e "${DIM}  The safe version of OpenClaw${NC}"
 echo ""
 
 # ---------------------------------------------------------------------------
+# Detect container runtime: prefer Podman, fall back to Docker
+# Verify daemon is actually running, not just that the CLI exists
+# ---------------------------------------------------------------------------
+CONTAINER_CMD=""
+if command -v podman &>/dev/null && podman info &>/dev/null; then
+    CONTAINER_CMD="podman"
+elif command -v docker &>/dev/null && docker info &>/dev/null; then
+    CONTAINER_CMD="docker"
+fi
+
+# ---------------------------------------------------------------------------
 # Interactive preference selector
 # ---------------------------------------------------------------------------
 if [ -t 0 ]; then
+    if [ -n "$CONTAINER_CMD" ]; then
+        runtime_label="$CONTAINER_CMD"
+    else
+        runtime_label="Podman/Docker"
+    fi
     echo -e "  How do you want to run SafeClaw?"
     echo ""
-    echo -e "  ${CYAN}[1]${NC} Docker ${GREEN}(recommended)${NC} — sandboxed, no access to your files"
+    echo -e "  ${CYAN}[1]${NC} Container (${runtime_label}) ${GREEN}(recommended)${NC} — sandboxed, no access to your files"
     echo -e "  ${CYAN}[2]${NC} pip install — runs on host, developer mode"
     echo -e "  ${CYAN}[3]${NC} I already have it installed"
     echo ""
@@ -33,8 +49,8 @@ if [ -t 0 ]; then
     read -r choice
     choice=${choice:-1}
 else
-    # Non-interactive (piped) — default to Docker if available, else pip
-    if command -v docker &>/dev/null; then
+    # Non-interactive (piped) — default to container if available, else pip
+    if [ -n "$CONTAINER_CMD" ]; then
         choice=1
     else
         choice=2
@@ -43,17 +59,18 @@ fi
 
 case "$choice" in
     1)
-        # Docker path
-        if ! command -v docker &>/dev/null; then
-            echo -e "  ${RED}Docker not found.${NC}"
+        # Container path
+        if [ -z "$CONTAINER_CMD" ]; then
+            echo -e "  ${RED}No container runtime found.${NC}"
             echo ""
-            echo "  Install Docker: https://docs.docker.com/get-docker/"
+            echo "  Install Podman (recommended): https://podman.io/docs/installation"
+            echo "  Or Docker Desktop: https://docs.docker.com/get-docker/"
             echo "  Or choose option 2 (pip install) instead."
             exit 1
         fi
 
-        echo -e "  ${CYAN}Pulling SafeClaw proxy image...${NC}"
-        docker pull ghcr.io/aceteam-ai/aep-proxy:latest 2>&1 | tail -3
+        echo -e "  ${CYAN}Pulling SafeClaw proxy image via ${CONTAINER_CMD}...${NC}"
+        $CONTAINER_CMD pull ghcr.io/aceteam-ai/aep-proxy:latest 2>&1 | tail -3
 
         mkdir -p "$HOME/safeclaw"
 
@@ -62,9 +79,10 @@ case "$choice" in
         echo ""
         echo -e "  ${CYAN}Start SafeClaw:${NC}"
         echo ""
-        echo "    docker run -p 8899:8899 -e OPENAI_API_KEY=\$OPENAI_API_KEY -v ~/safeclaw:/workspace ghcr.io/aceteam-ai/aep-proxy"
+        echo "    $CONTAINER_CMD run -p 8899:8899 -v ~/safeclaw:/workspace ghcr.io/aceteam-ai/aep-proxy"
         echo ""
         echo -e "  ${CYAN}Dashboard:${NC}  http://localhost:8899/aep/"
+        echo -e "  ${CYAN}API Keys:${NC}   Configure in Dashboard > Settings"
         echo -e "  ${CYAN}Workspace:${NC} ~/safeclaw (the only folder your agent can see)"
         echo ""
         echo -e "${DIM}  Your agent runs in a container. It can only access ~/safeclaw.${NC}"
@@ -79,8 +97,25 @@ case "$choice" in
         fi
 
         echo -e "  ${CYAN}Installing aceteam-aep...${NC}"
-        uv pip install --system "aceteam-aep[all]" --quiet 2>/dev/null \
-            || uv pip install "aceteam-aep[all]" --quiet
+        # Use uv pip install with various fallback strategies for different environments
+        if command -v uv &>/dev/null; then
+            uv pip install --quiet "aceteam-aep[all]" --system 2>/dev/null || \
+            UV_SYSTEM_PYTHON=1 uv pip install --quiet "aceteam-aep[all]" 2>/dev/null || \
+            uv pip install --quiet "aceteam-aep[all]" 2>/dev/null || true
+        fi
+
+        # If uv failed or isn't used, try pip with --break-system-packages (for managed envs like Debian)
+        if ! command -v aceteam-aep &>/dev/null; then
+            pip install --quiet "aceteam-aep[all]" --break-system-packages 2>/dev/null || \
+            python3 -m pip install --quiet "aceteam-aep[all]" --break-system-packages 2>/dev/null || \
+            pip install --quiet "aceteam-aep[all]" 2>/dev/null || \
+            python3 -m pip install --quiet "aceteam-aep[all]" 2>/dev/null || true
+        fi
+
+        if ! command -v aceteam-aep &>/dev/null; then
+            echo -e "  ${RED}Installation failed.${NC} Please install aceteam-aep manually: pip install aceteam-aep[all]"
+            exit 1
+        fi
 
         echo ""
         echo -e "  ${GREEN}${BOLD}Ready.${NC}"
@@ -109,3 +144,39 @@ echo ""
 echo -e "${DIM}  SafeClaw: github.com/aceteam-ai/safeclaw${NC}"
 echo -e "${DIM}  Workshop: github.com/aceteam-ai/aep-quickstart/blob/main/workshop/bootcamp.html${NC}"
 echo ""
+
+# ---------------------------------------------------------------------------
+# Workshop outro — QR codes + coupon prompt
+# ---------------------------------------------------------------------------
+if [ -t 0 ] && command -v qrencode &>/dev/null; then
+    echo -e "  ${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo -e "  ${BOLD}Connect with me on LinkedIn${NC}        ${BOLD}Star SafeClaw on GitHub${NC}"
+    echo ""
+
+    # Generate QR codes side by side
+    LI_QR=$(qrencode -t UTF8 -m 1 "https://www.linkedin.com/in/sunapi386/" 2>/dev/null)
+    GH_QR=$(qrencode -t UTF8 -m 1 "https://github.com/aceteam-ai/safeclaw" 2>/dev/null)
+
+    if [ -n "$LI_QR" ] && [ -n "$GH_QR" ]; then
+        paste <(echo "$LI_QR") <(echo "$GH_QR") | while IFS=$'\t' read -r left right; do
+            printf "  %-36s  %s\n" "$left" "$right"
+        done
+    fi
+
+    echo ""
+    echo -e "  ${CYAN}linkedin.com/in/sunapi386${NC}          ${CYAN}github.com/aceteam-ai/safeclaw${NC}"
+    echo ""
+    echo -e "  ${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo -e "  ${BOLD}Reply ${GREEN}a${NC}${BOLD} to get a free SafeClaw hosted instance coupon!${NC}"
+    echo ""
+elif [ -t 0 ]; then
+    echo -e "  ${BOLD}${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo -e "  ${BOLD}Connect:${NC}  ${CYAN}linkedin.com/in/sunapi386${NC}"
+    echo -e "  ${BOLD}Star:${NC}     ${CYAN}github.com/aceteam-ai/safeclaw${NC}"
+    echo ""
+    echo -e "  ${BOLD}Reply ${GREEN}a${NC}${BOLD} to get a free SafeClaw hosted instance coupon!${NC}"
+    echo ""
+fi


### PR DESCRIPTION
## Summary
- Sync `install.sh` with safeclaw-site: daemon detection via `podman info` / `docker info`, PEP 668 pip fallbacks, workshop outro with QR codes and coupon prompt

## Test plan
- [ ] Run installer with Docker CLI present but daemon stopped — should fall back to pip
- [ ] Run installer interactively with `qrencode` — QR codes render side-by-side
- [ ] Run installer without `qrencode` — plain text links appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)