### PR TITLE
feat(compose): bind-mount openclaw config into aep-proxy for auto-sync

### DIFF
--- a/docker-compose.safe.yml
+++ b/docker-compose.safe.yml
@@ -29,6 +29,16 @@ services:
     environment:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      # When set, the proxy auto-syncs openclaw.json from the AceTeam gateway's
+      # /v1/models on every act_* connect. Same host path that the
+      # openclaw-gateway service mounts as its config dir, so changes the
+      # proxy writes are visible to OpenClaw on its next restart.
+      AEP_OPENCLAW_CONFIG_PATH: /openclaw-config/openclaw.json
+    volumes:
+      # Bind-mount the OpenClaw config dir so the proxy can refresh
+      # openclaw.json. Same source path as openclaw-gateway's volume,
+      # different mount point inside this container.
+      - ${OPENCLAW_CONFIG_DIR:-${HOME:-/tmp}/.openclaw}:/openclaw-config:rw
     healthcheck:
       test:
         [


### PR DESCRIPTION
## Summary

Adds an \`AEP_OPENCLAW_CONFIG_PATH\` env var + a bind mount of the OpenClaw config dir into the aep-proxy container, so the proxy can rewrite \`openclaw.json\` after the user connects via the dashboard.

Pairs with aceteam-ai/aceteam-aep#106 which adds the actual sync logic. Without that proxy-side code, this compose change is a no-op.

## Why

Previously openclaw.json was a static hand-seeded JSON file (in \`safeclaw-site/install.sh::write_openclaw_config\`). Adding a TokenRouter model meant editing this seed AND each user's local install. The auto-sync path makes /v1/models on the AceTeam gateway the single source of truth — the proxy mirrors it into the user's openclaw.json on every connect, so model picker UI tracks the live catalog automatically.

## Verification

- [x] \`docker compose -f docker-compose.yml -f docker-compose.safe.yml config\` parses cleanly with the new mount + env
- [ ] After deploy + aceteam-aep#106 merge: connect via SafeClaw dashboard with an act_* key, confirm openclaw.json gets rewritten, dashboard surfaces "restart gateway to apply" banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)