### PR TITLE
feat(podman): rootless Podman support — keep-id overlay + install.sh wiring

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ docker pull ghcr.io/aceteam-ai/aep-proxy:latest
 The easiest way to run the full SafeClaw agent with automatic safety enforcement is using Docker Compose:
 
 ```bash
-# Docker 
+# Docker
 docker compose -f docker-compose.yml -f docker-compose.safe.yml up
 
-# Podman
-podman-compose -f docker-compose.yml -f docker-compose.safe.yml up
+# Podman (rootless — adds keep-id overlay so files land owned by your host user)
+podman-compose -f docker-compose.yml -f docker-compose.safe.yml -f docker-compose.podman.yml up
 ```
 
 ## Running the Safety Proxy Alone
@@ -92,11 +92,11 @@ The agent runs inside a Docker container. It **cannot** access your files, email
 The easiest way to run the full SafeClaw agent with automatic safety enforcement is using Docker Compose:
 
 ```bash
-# Docker 
+# Docker
 docker compose -f docker-compose.yml -f docker-compose.safe.yml up
 
-# Podman
-podman-compose -f docker-compose.yml -f docker-compose.safe.yml up
+# Podman (rootless — adds keep-id overlay so files land owned by your host user)
+podman-compose -f docker-compose.yml -f docker-compose.safe.yml -f docker-compose.podman.yml up
 ```
 
 ## Running the Safety Proxy Alone
@@ -251,6 +251,7 @@ aceteam-aep wrap -- python my_agent.py
 [palebluedot.ai](https://palebluedot.ai/) (makers of **TokenRouter**) is partnered with us. Get **$200 in AceTeam credits** — **50 vouchers** available.
 
 **To claim:**
+
 1. Sign up at [aceteam.ai](https://aceteam.ai)
 2. [Star this repo](https://github.com/aceteam-ai/safeclaw)
 3. [DM Jason on LinkedIn](https://www.linkedin.com/in/sunapi386/) — mention TokenRouter

--- a/SAFECLAW.md
+++ b/SAFECLAW.md
@@ -30,6 +30,20 @@ docker compose -f docker-compose.yml -f docker-compose.safe.yml up
 
 Dashboard: **http://localhost:8899/dashboard/**
 
+### Option 1b: Podman (rootless — recommended over Docker on Linux)
+
+```bash
+podman-compose -f docker-compose.yml -f docker-compose.safe.yml -f docker-compose.podman.yml up
+```
+
+Why prefer Podman: rootless user namespaces map the container's uid 0 to your
+host user, so files the proxy writes to `~/safeclaw/config/openclaw.json`
+land owned by you — no `sudo` needed to edit them. The `docker-compose.podman.yml`
+overlay adds `userns_mode: keep-id` for the openclaw-gateway service so its
+`node` user (uid 1001) also maps cleanly to your host UID instead of a high
+subuid. The installer auto-detects Podman and prefers it over Docker when
+both are available.
+
 ### Option 2: Wrap any existing OpenClaw install
 
 ```bash

--- a/docker-compose.podman.yml
+++ b/docker-compose.podman.yml
@@ -1,0 +1,27 @@
+# docker-compose.podman.yml
+#
+# Podman-specific overlay. Compose with docker-compose.yml + docker-compose.safe.yml
+# when running under rootless Podman:
+#
+#   podman-compose -f docker-compose.yml -f docker-compose.safe.yml -f docker-compose.podman.yml up
+#
+# Why a separate overlay: `userns_mode: "keep-id"` is Podman-specific and would
+# error under Docker (Docker only accepts `host`). Keeping it isolated lets
+# Docker users continue with the default 2-file compose chain.
+#
+# What keep-id does: maps the host user's UID into the container so files
+# written by the container's `node` user (uid 1001) land on the host owned
+# by the host user instead of a high subuid. Without this, ls -la on the
+# bind-mounted config/workspace dirs shows confusing owners like 100999.
+#
+# aep-proxy is intentionally NOT given keep-id. It runs as root inside the
+# container; under default rootless Podman the container's uid 0 already
+# maps to the host user, which is exactly what we want for openclaw.json
+# bind-mount writes.
+
+services:
+  openclaw-gateway:
+    userns_mode: "keep-id"
+
+  openclaw-cli:
+    userns_mode: "keep-id"

--- a/install.sh
+++ b/install.sh
@@ -175,6 +175,10 @@ case "$choice" in
             -o "$SAFECLAW_DIR/docker-compose.yml"
         curl -fsSL "https://raw.githubusercontent.com/aceteam-ai/safeclaw/main/docker-compose.safe.yml" \
             -o "$SAFECLAW_DIR/docker-compose.safe.yml"
+        # Podman-specific overlay (userns_mode: keep-id). Harmless to download for
+        # docker users — only included in the start command when CONTAINER_CMD=podman.
+        curl -fsSL "https://raw.githubusercontent.com/aceteam-ai/safeclaw/main/docker-compose.podman.yml" \
+            -o "$SAFECLAW_DIR/docker-compose.podman.yml" 2>/dev/null || true
         curl -fsSL "https://raw.githubusercontent.com/aceteam-ai/safeclaw/main/.env.example" \
             -o "$SAFECLAW_DIR/.env.example" 2>/dev/null || true
 
@@ -207,7 +211,13 @@ ENVEOF
         echo ""
         echo "    cd ~/safeclaw"
         echo "    # Add your API keys to .env first"
-        echo "    $CONTAINER_CMD compose -f docker-compose.yml -f docker-compose.safe.yml up"
+        if [ "$CONTAINER_CMD" = "podman" ]; then
+            # Rootless Podman: use the keep-id overlay so the openclaw-gateway's
+            # `node` uid (1001) maps to the host user instead of a high subuid.
+            echo "    $CONTAINER_CMD compose -f docker-compose.yml -f docker-compose.safe.yml -f docker-compose.podman.yml up"
+        else
+            echo "    $CONTAINER_CMD compose -f docker-compose.yml -f docker-compose.safe.yml up"
+        fi
         echo ""
         echo -e "  ${CYAN}Dashboard:${NC}       http://localhost:8899/aep/"
         echo -e "  ${CYAN}Agent UI:${NC}        http://localhost:18789/"

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,28 @@ elif command -v docker &>/dev/null && docker info &>/dev/null; then
 fi
 
 # ---------------------------------------------------------------------------
+# Resolve the compose command. Docker has `docker compose` (v2 plugin) or
+# `docker-compose` (v1, deprecated). Podman has `podman compose` (built-in
+# on 4.x+ when the plugin is present) or `podman-compose` (separate Python
+# package, more widely installed). Pick whichever responds to --version so
+# the printed `Start SafeClaw` hint actually works on the user's machine.
+# ---------------------------------------------------------------------------
+detect_compose_cmd() {
+    local runtime="$1"
+    if [ -z "$runtime" ]; then
+        return
+    fi
+    if "$runtime" compose version &>/dev/null; then
+        echo "$runtime compose"
+    elif command -v "${runtime}-compose" &>/dev/null; then
+        echo "${runtime}-compose"
+    else
+        echo "$runtime compose"  # last resort — let the user see the failure
+    fi
+}
+COMPOSE_CMD="$(detect_compose_cmd "$CONTAINER_CMD")"
+
+# ---------------------------------------------------------------------------
 # Auto-install Docker/Podman if missing
 # ---------------------------------------------------------------------------
 install_container_runtime() {
@@ -63,18 +85,21 @@ install_container_runtime() {
             fi
             ;;
         Linux)
+            # Pull podman + podman-compose together. The base `podman` package
+            # alone doesn't include a compose CLI on most distros, and the
+            # printed `Start SafeClaw` hint relies on having one available.
             if command -v apt-get &>/dev/null; then
                 echo -e "  ${CYAN}Installing Podman via apt...${NC}"
-                sudo apt-get update -qq && sudo apt-get install -y -qq podman
+                sudo apt-get update -qq && sudo apt-get install -y -qq podman podman-compose
             elif command -v dnf &>/dev/null; then
                 echo -e "  ${CYAN}Installing Podman via dnf...${NC}"
-                sudo dnf install -y podman
+                sudo dnf install -y podman podman-compose
             elif command -v pacman &>/dev/null; then
                 echo -e "  ${CYAN}Installing Podman via pacman...${NC}"
-                sudo pacman -S --noconfirm podman
+                sudo pacman -S --noconfirm podman podman-compose
             elif command -v zypper &>/dev/null; then
                 echo -e "  ${CYAN}Installing Podman via zypper...${NC}"
-                sudo zypper install -y podman
+                sudo zypper install -y podman podman-compose
             else
                 echo -e "  ${RED}Could not detect package manager.${NC}"
                 echo "  Install Podman: https://podman.io/docs/installation"
@@ -92,6 +117,7 @@ install_container_runtime() {
                 echo "  Try: sudo systemctl start podman"
                 exit 1
             fi
+            COMPOSE_CMD="$(detect_compose_cmd "$CONTAINER_CMD")"
             echo -e "  ${GREEN}Installed ${CONTAINER_CMD}.${NC}"
             ;;
         *)
@@ -214,9 +240,9 @@ ENVEOF
         if [ "$CONTAINER_CMD" = "podman" ]; then
             # Rootless Podman: use the keep-id overlay so the openclaw-gateway's
             # `node` uid (1001) maps to the host user instead of a high subuid.
-            echo "    $CONTAINER_CMD compose -f docker-compose.yml -f docker-compose.safe.yml -f docker-compose.podman.yml up"
+            echo "    $COMPOSE_CMD -f docker-compose.yml -f docker-compose.safe.yml -f docker-compose.podman.yml up"
         else
-            echo "    $CONTAINER_CMD compose -f docker-compose.yml -f docker-compose.safe.yml up"
+            echo "    $COMPOSE_CMD -f docker-compose.yml -f docker-compose.safe.yml up"
         fi
         echo ""
         echo -e "  ${CYAN}Dashboard:${NC}       http://localhost:8899/aep/"


### PR DESCRIPTION
## Summary

- Adds \`docker-compose.podman.yml\` overlay with \`userns_mode: keep-id\` for openclaw-gateway/cli services
- \`install.sh\` already preferred Podman; now also downloads the overlay and prints the 3-file compose command under \`CONTAINER_CMD=podman\`
- SAFECLAW.md gets an "Option 1b: Podman" section explaining the rootless benefit

## Why

Aep-proxy auto-syncs \`openclaw.json\` from inside a root-running container. Under Docker that file lands as \`root:root\` on the bind mount; aceteam-aep v0.10.2 already chmod's it to 0666 so the host user can edit it without sudo, but that's a workaround. Rootless Podman is the proper fix — container uid 0 maps to the host user via user namespaces, so writes land owned by the host user with normal 0644 perms.

The \`keep-id\` overlay is separate from \`docker-compose.safe.yml\` because Docker rejects \`userns_mode: \"keep-id\"\` (Docker only accepts \"host\"). Keeping it isolated lets Docker users continue with the existing 2-file compose chain unchanged.

aep-proxy is intentionally NOT given keep-id — it runs as root inside the container and the default rootless mapping (container uid 0 → host user) is exactly what we want for the bind-mount writes. Only openclaw-gateway / openclaw-cli (which run as \`node\`, uid 1001) need keep-id so their files don't appear as a subuid like 100999 on the host.

## Test plan

- [x] \`bash -n install.sh\` passes
- [ ] End-to-end test under Podman + podman-compose (couldn't verify in sandbox; needs hands-on run)
- [ ] Verify \`~/safeclaw/config/openclaw.json\` lands owned by the host user under rootless Podman after an \`act_*\` connect (no chmod 0666 needed)
- [ ] Verify Docker users with the existing 2-file compose chain are unaffected

Closes #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)